### PR TITLE
Allow to configure redis server host and port

### DIFF
--- a/board-linuxfr.gemspec
+++ b/board-linuxfr.gemspec
@@ -1,4 +1,6 @@
 # encoding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require './lib/board-linuxfr'
 
 Gem::Specification.new do |s|

--- a/lib/board-linuxfr/redis_plugin.rb
+++ b/lib/board-linuxfr/redis_plugin.rb
@@ -12,7 +12,7 @@ class BoardLinuxfr
       @logger = logger
       @chans  = status[:channels] = Hash.new { |h,k| h[k] = EM::Channel.new }
       @cache  = status[:cache]    = Cache.new
-      @redis  = Redis.new
+      @redis  = Redis.new(host: ENV['REDIS_HOST'] || "localhost", port: ENV['REDIS_PORT'] || 6379)
     end
 
     def run

--- a/lib/board-linuxfr/version.rb
+++ b/lib/board-linuxfr/version.rb
@@ -1,3 +1,3 @@
 class BoardLinuxfr
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
I'm trying to build a Docker-Compose development environment for Linuxfr.org and I need to be able to set up the Redis server to use for the board tool.

As I didn't know how to add run option, I've just set it up with env variable, as that's exactly what I need for Docker.

See the [suivi request](https://linuxfr.org/suivi/board-linuxfr-reparer-le-build-et-permettre-de-configurer-le-host-et-port-du-serveur-redis#comment-1824282).