### PR TITLE
rename the whole project with the git repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ when something is said with Server-Sent Event / EventSource.
 How to use it?
 --------------
 
-You can nstall the gem with `gem install board-linuxfr` [using the linuxfrorg
-Github Package Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-rubygems-registry#installing-a-package).
-Then, you can launch it on local with `board-linuxfr -S /tmp/board.sock`
+You can nstall the gem with `gem install board-sse-linuxfr.org`.
+
+Then, you can launch it on local with `board-sse-linuxfr.org -S /tmp/board.sock`
 and it will listen on a UNIX socket at `/tmp/board.sock`.
 
 Another way is to use a container engine (like Docker or Podman) and a
@@ -23,8 +23,8 @@ See also
 --------
 
 * [Git repository](https://github.com/linuxfrorg/board-sse-LinuxFr.org)
-* For versions >= 0.1.4: [Github Package repostory](https://github.com/linuxfrorg/board-sse-linuxfr.org/pkgs/rubygems/board-linuxfr)
-* For older version: [Rubygems page](https://rubygems.org/gems/board-linuxfr)
+* For versions >= 1.0.0: [Rubygems board-sse-linuxfr.org](https://rubygems.org/gems/board-sse-linuxfr.org)
+* For older version: [old Rubygems board-linuxfr](https://rubygems.org/gems/board-linuxfr)
 
 
 Copyright

--- a/bin/board-linuxfr
+++ b/bin/board-linuxfr
@@ -1,3 +1,0 @@
-#!/usr/bin/env ruby
-
-require "board-linuxfr"

--- a/bin/board-sse-linuxfr.org
+++ b/bin/board-sse-linuxfr.org
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+
+require "board-sse-linuxfr.org"

--- a/board-sse-linuxfr.org.gemspec
+++ b/board-sse-linuxfr.org.gemspec
@@ -1,21 +1,24 @@
 # encoding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require './lib/board-linuxfr/version'
+require './lib/board-sse-linuxfr.org/version'
 
 Gem::Specification.new do |s|
   s.name         = "board-sse-linuxfr.org"
-  s.version      = BoardLinuxfr::VERSION
+  s.version      = BoardSseLinuxfrOrg::VERSION
   s.licenses     = ["AGPL-3.0-only"]
   s.authors      = ["Bruno Michel", "Adrien Dorsaz"]
   s.email        = "adrien@adorsaz.ch"
   s.homepage     = "https://github.com/linuxfrorg/board-sse-linuxfr.org"
-  s.summary      = "Push notifications for the board of LinuxFr.org"
-  s.description  = "Push notifications for the board of LinuxFr.org via Server-Sent Events"
+  s.summary      = "Board for LinuxFr.org"
+  s.description  = <<~EOD
+    Users of the LinuxFr.org website can chat on a space called the board (« la tribune » in french).
+    This Ruby daemon notifies the users when something is said with Server-Sent Event / EventSource.
+  EOD
 
   s.files        = Dir['lib/**/*.rb'] + Dir['bin/*']
   s.platform     = Gem::Platform::RUBY
-  s.executables  = ["board-linuxfr"]
+  s.executables  = ["board-sse-linuxfr.org"]
   s.require_path = 'lib'
 
   s.add_runtime_dependency "goliath",   "~>1.0", ">= 1.0.7"

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,5 @@
 services:
-  linuxfr-board:
+  board-sse-linuxfr.og:
     build:
       context: .
       dockerfile: ./deployment/Containerfile

--- a/deployment/Containerfile
+++ b/deployment/Containerfile
@@ -1,7 +1,10 @@
-FROM ruby:3-slim-bookworm AS build
+FROM docker.io/ruby:3-slim-bookworm AS build
 
-LABEL org.opencontainers.image.title="LinuxFr.org boards"
 LABEL org.opencontainers.image.description="Chat rooms for LinuxFr"
+
+LABEL org.opencontainers.image.title="Board for LinuxFr.org"
+LABEL org.opencontainers.image.description="Users of the LinuxFr.org website can chat on a space called the board (« la tribune » in french). \
+This Ruby daemon notifies the users when something is said with Server-Sent Event / EventSource."
 LABEL org.opencontainers.image.source="https://github.com/linuxfrorg/board-sse-linuxfr.org"
 LABEL org.opencontainers.image.url="https://github.com/linuxfrorg/board-sse-linuxfr.org"
 LABEL org.opencontainers.image.licenses="AGPL-3.0-only"
@@ -19,16 +22,16 @@ RUN \
   apt-get clean;
 
 USER ${UID}
-WORKDIR /linuxfr-board
-ENV HOME=/linuxfr-board
+WORKDIR /board-sse-linuxfr.org
+ENV HOME=/board-sse-linuxfr.org
 
-# Install board-linuxfr
+# Install board-sse-linuxfr.org
 COPY --chown=${UID}:0 --chmod=770 . .
-RUN gem build board-linuxfr.gemspec
+RUN gem build board-sse-linuxfr.org.gemspec
 
-FROM build as productioproduction
+FROM build as production
 
-RUN gem install ./board-linuxfr-*.gem
+RUN gem install ./board-sse-linuxfr.org-*.gem
 
 # Clean development dependencies
 USER 0
@@ -37,5 +40,5 @@ RUN apt purge --autoremove -y build-essential ruby-dev
 USER ${UID}
 EXPOSE 9000
 
-CMD ["board-linuxfr"]
+CMD ["board-sse-linuxfr.org"]
 

--- a/lib/board-linuxfr/version.rb
+++ b/lib/board-linuxfr/version.rb
@@ -1,3 +1,0 @@
-class BoardLinuxfr
-  VERSION = "0.1.5"
-end

--- a/lib/board-sse-linuxfr.org.rb
+++ b/lib/board-sse-linuxfr.org.rb
@@ -2,10 +2,10 @@ require "goliath"
 require "yajl"
 
 
-class BoardLinuxfr < Goliath::API
-  autoload :Cache,       "board-linuxfr/cache"
-  autoload :RedisPlugin, "board-linuxfr/redis_plugin"
-  autoload :VERSION,     "board-linuxfr/version"
+class BoardSseLinuxfrOrg < Goliath::API
+  autoload :Cache,       "board-sse-linuxfr.org/cache"
+  autoload :RedisPlugin, "board-sse-linuxfr.org/redis_plugin"
+  autoload :VERSION,     "board-sse-linuxfr.org/version"
 
   plugin RedisPlugin
 

--- a/lib/board-sse-linuxfr.org/cache.rb
+++ b/lib/board-sse-linuxfr.org/cache.rb
@@ -1,4 +1,4 @@
-class BoardLinuxfr
+class BoardSseLinuxfrOrg
   class Cache
     CAPACITY = 10
 

--- a/lib/board-sse-linuxfr.org/redis_plugin.rb
+++ b/lib/board-sse-linuxfr.org/redis_plugin.rb
@@ -2,10 +2,10 @@ require "hiredis"
 require "em-synchrony"
 require "redis"
 require "redis/connection/synchrony"
-require "board-linuxfr/cache"
+require "board-sse-linuxfr.org/cache"
 
 
-class BoardLinuxfr
+class BoardSseLinuxfrOrg
   class RedisPlugin
     def initialize(address, port, config, status, logger)
       logger.info "Initializing the Redis plugin"

--- a/lib/board-sse-linuxfr.org/version.rb
+++ b/lib/board-sse-linuxfr.org/version.rb
@@ -1,0 +1,3 @@
+class BoardSseLinuxfrOrg
+  VERSION = "1.0.0"
+end


### PR DESCRIPTION
We lost access to the board-linuxfr gem so we needed a new name to publish new versions. The simplest was to use the name of the repository.

To reflect this breaking change, manjor version has been increased too.